### PR TITLE
Specify numpy==1.18.5 since latest default v1.19+ is incompatible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN echo "Installing dependencies..." && \
 	libcanberra-gtk-module \
 	libopencv-dev && \
 	python3 -m pip install \
-	numpy \
+	numpy==1.18.5 \
 	protobuf \
 	opencv-python
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,36 @@
 # openpose-docker
-Dockerfile to build the excellent OpenPose software from CMU.
 
-Ensure that you have `nvidia-docker` installed before you download this image.
+Dockerfile to build the excellent [OpenPose](https://github.com/CMU-Perceptual-Computing-Lab/openpose) software from CMU.
 
-To run the container, use the following commmand - 
+## Prerequisites
 
-```bash
-xhost +
-docker run -it --net=host -e DISPLAY --runtime=nvidia <container-id>
+Ensure that you have the latest version of Docker installed. For versions prior to 19.03, you may need to install `nvidia-docker`. Read more [here](https://github.com/NVIDIA/nvidia-docker).
+
+## Getting Started
+
+Pull the image from Docker Hub -
+
+```
+$ docker pull exsidius/openpose
 ```
 
-Supports - 
+To run the container (name given: `openpose`), use the following commmands -
+
+```
+$ docker stop openpose && docker rm openpose
+$ docker run -it \
+        --gpus all \
+        --name openpose \
+        exsidius/openpose
+```
+
+Now, you should be inside the interactive docker container, i.e.  
+`root@<hash>:/openpose# `
+
+_Note_: Remove the `--gpus all` flag if you want to run the container without GPUs.
+
+### Supports
+
 1. CUDA 10
-2. CUDnn 7
-3. Python 3 (will be 3.7 soon)
+2. cuDNN 7
+3. Python 3.5.2 (will be 3.7 soon)


### PR DESCRIPTION
@ExSidius The current latest docker image (https://hub.docker.com/r/exsidius/openpose) is broken since the [20-JUN-2020 release](https://github.com/numpy/numpy/releases/tag/v1.19.0) of `numpy` v1.19.0, which only supports Python 3.6+. The default python3 installation on Ubuntu 16.04 is v3.5.2, hence the specific `numpy=1.18.5` supporting Python 3.5 needs to be mentioned in the Dockerfile.

The README.md file has also been updated to reflect the deprecation of `nvidia-docker` in the Docker versions 19.03+. The build steps mentioned have been tested.